### PR TITLE
stop mender-inventory-geo hanging due to wget

### DIFF
--- a/support/mender-inventory-geo
+++ b/support/mender-inventory-geo
@@ -40,7 +40,7 @@ ATTR_NAME_LAT="geo-lat"
 ATTR_NAME_LON="geo-lon"
 
 if [ ! -f "${TEMPFILE}" ]; then
-    ipinfo=$(wget --timeout=${TIMEOUT} -q -O /dev/stdout \
+    ipinfo=$(wget --timeout=${TIMEOUT} -q -O /dev/stdout --tries=2\
                   --header 'Accept: application/json' \
                   https://ipinfo.io)
     if [ $? != 0 ] || [ -z "${ipinfo}" ]; then


### PR DESCRIPTION
wget in this script has a timeout but wget will retry indefinitely, and hardware deployed on sites where access it restricted occasionally cannot reach ipinfo.io, and the script effectively hangs, and no inventory data is sent to mender. Limiting to 2 attempts resolves the issue and allows wget to finish and the error reported


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: wget indefinite retries causes it to effectively hang


Changelog: None
Ticket: None
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
